### PR TITLE
feat(resumable_upload): fix http response status code checking to include the 308 status

### DIFF
--- a/android/src/main/java/com/bluechilli/flutteruploader/UploadWorker.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/UploadWorker.java
@@ -269,7 +269,7 @@ public class UploadWorker extends ListenableWorker implements CountProgressListe
         responseString = body.string();
       }
 
-      if (!response.isSuccessful()) {
+      if (!response.isSuccessful() && statusCode != 308) {
         return Result.failure(
             createOutputErrorData(
                 UploadStatus.FAILED, statusCode, "upload_error", responseString, null));

--- a/ios/Classes/URLSessionUploader.swift
+++ b/ios/Classes/URLSessionUploader.swift
@@ -360,6 +360,6 @@ extension URLSessionUploader: URLSessionDelegate, URLSessionDataDelegate, URLSes
     }
 
     private func isRequestSuccessful(_ statusCode: Int) -> Bool {
-        return statusCode >= 200 && statusCode <= 299
+        return statusCode >= 200 && statusCode <= 299 || statusCode == 308
     }
 }


### PR DESCRIPTION
The 308 status is required by the google resumable uploads endpoint: https://cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload